### PR TITLE
Add login API endpoint for device authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+__pycache__/

--- a/api/login.py
+++ b/api/login.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from typing import Callable
+import os
+import requests
+
+router = APIRouter(prefix="/api")
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str
+
+def firebase_email_password_login(email: str, password: str) -> str:
+    api_key = os.environ.get("NEXT_PUBLIC_FIREBASE_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=500, detail="Missing Firebase API key")
+    url = f"https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key={api_key}"
+    payload = {"email": email, "password": password, "returnSecureToken": True}
+    try:
+        resp = requests.post(url, json=payload, timeout=10)
+    except requests.RequestException as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    if resp.status_code != 200:
+        try:
+            message = resp.json().get("error", {}).get("message", "Invalid credentials")
+        except Exception:
+            message = "Invalid credentials"
+        raise HTTPException(status_code=400, detail=message)
+    data = resp.json()
+    uid = data.get("localId")
+    if not uid:
+        raise HTTPException(status_code=400, detail="Invalid response from auth server")
+    return uid
+
+def get_login_verifier() -> Callable[[str, str], str]:
+    return firebase_email_password_login
+
+@router.post("/login")
+async def login(payload: LoginRequest, verifier: Callable[[str, str], str] = Depends(get_login_verifier)):
+    uid = verifier(payload.email, payload.password)
+    return {"uid": uid}

--- a/api/main.py
+++ b/api/main.py
@@ -19,6 +19,7 @@ from .records import router as records_router
 from .command import router as command_router
 from .auth import router as auth_router
 from .admin import router as admin_router
+from .login import router as login_router
 
 # Load env from project root `.env.local` (best-effort) for local dev
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -81,5 +82,6 @@ app.include_router(records_router)
 app.include_router(command_router)
 app.include_router(auth_router)
 app.include_router(admin_router)
+app.include_router(login_router)
 
 # Note: On Vercel Python runtime, export ASGI app as `app` (no Mangum wrapper needed)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,14 @@ class FakeDBRef:
     def delete(self) -> None:
         _delete_path(self._store, self._path)
 
+    def update(self, value: Dict[str, Any]) -> None:
+        for k, v in value.items():
+            if self._path == "/":
+                path = f"/{k}".rstrip("/")
+            else:
+                path = f"{self._path}/{k}".rstrip("/")
+            _assign_path(self._store, path, v)
+
     def push(self, value: Dict[str, Any]) -> FakePushResult:
         base = _lookup_path(self._store, self._path)
         if base is None or not isinstance(base, dict):
@@ -245,6 +253,12 @@ def _build_fake_firebase_module() -> types.ModuleType:
             pass
 
     mod.auth = _AuthNS()
+
+    class _ExceptionsNS:  # minimal exceptions namespace
+        class InvalidArgumentError(Exception):
+            pass
+
+    mod.exceptions = _ExceptionsNS
 
     return mod
 

--- a/tests/test_api_main.py
+++ b/tests/test_api_main.py
@@ -30,7 +30,7 @@ def test_records_post_and_get(client, fake_store):  # noqa: ANN001
     }
 
     # Post a record (device_id provided by dependency override -> dev1)
-    payload = {"ts": 1000, "value": 42}
+    payload = {"spo2": 98, "heart_rate": 70}
     res = client.post("/api/records/", json=payload)
     assert res.status_code == 200
     key = res.json()["key"]
@@ -49,6 +49,7 @@ def test_records_post_and_get(client, fake_store):  # noqa: ANN001
 
 def test_records_register_device(client, fake_store):  # noqa: ANN001
     _reset_store(fake_store)
+    fake_store["devices"]["dev2"] = {"secret": "sec2"}
     res = client.post(
         "/api/records/device/register",
         json={"device_id": "dev2", "device_secret": "sec2"},

--- a/tests/test_login_api.py
+++ b/tests/test_login_api.py
@@ -1,0 +1,25 @@
+from fastapi import HTTPException
+
+from api.login import get_login_verifier
+
+
+def test_login_success(client):
+    client.app.dependency_overrides[get_login_verifier] = lambda: (
+        lambda email, password: "uid123"
+    )
+    res = client.post("/api/login", json={"email": "u@example.com", "password": "pw"})
+    assert res.status_code == 200
+    assert res.json()["uid"] == "uid123"
+    client.app.dependency_overrides.pop(get_login_verifier, None)
+
+
+def test_login_failure(client):
+    def fail_login(email, password):  # noqa: ARG001
+        raise HTTPException(status_code=400, detail="Invalid credentials")
+
+    client.app.dependency_overrides[get_login_verifier] = lambda: fail_login
+    res = client.post("/api/login", json={"email": "u@example.com", "password": "wrong"})
+    assert res.status_code == 400
+    body = res.json()
+    assert "detail" in body
+    client.app.dependency_overrides.pop(get_login_verifier, None)


### PR DESCRIPTION
## Summary
- implement `/api/login` endpoint using Firebase email/password auth
- expose router in main app
- add unit tests for login, adjust test fixtures and records tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4835e8b84832c909104a885054163